### PR TITLE
Tweak boxfile.yml to improve Nanobox experience

### DIFF
--- a/boxfile.yml
+++ b/boxfile.yml
@@ -5,20 +5,22 @@ run.config:
   engine.config:
     runtime: ruby-2.4.0
 
-# add extra packages
+  # add extra packages
   extra_packages:
     - nodejs
     - nginx
 
-deploy.config:
-  transform:
+  extra_steps:
     - gem install bundle
     - bundle install
-    - rake db:create
-    - rake db:migrate
-    - redis-server --daemonize yes
 
-# add a databas
+deploy.config:
+  before_live:
+    web.main:
+      - rake db:create
+      - rake db:migrate
+
+# add a database
 data.db:
   image: nanobox/postgresql:9.5
 
@@ -43,3 +45,10 @@ web.main:
 # add a worker component and give it a "start" command
 # worker.main:
 #   start: sidekiq
+#
+#   writable_dirs:
+#     - tmp
+#     - log
+#
+#   log_watch:
+#     rails: 'log/production.log'


### PR DESCRIPTION
- Run dependency updates in the dev build process, so local dev benefits as well
- Move DB changes to the stage where everything is properly set up to handle them; `transform` is meant for FS changes
- Don't run `redis-server` manually - it gets started automatically in `data.redis` already

You obviously don't have to merge this, but it should improve your experience, especially while developing the code parts.