### PR TITLE
Set Redis connection to correct host

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,4 +6,4 @@ test:
 
 production:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: redis://<%= ENV['DATA_REDIS_HOST'] %>:6379/1


### PR DESCRIPTION
That should fix Redis, too. Sorry I missed this the first time; should have used the search feature.

You ... might want to reactivate the worker component in the Boxfile, too. It does look like it wants to use it in production.